### PR TITLE
Update version.yml

### DIFF
--- a/yml/microsoft/built-in/version.yml
+++ b/yml/microsoft/built-in/version.yml
@@ -226,6 +226,23 @@ VulnerableExecutables:
 - Path: '%APPDATA%\Zoom\bin\Zoom.exe'
   Condition: Zoom for Windows <= 5.11.1 (6602)
   Type: Sideloading
+- Path: '%SYSTEM32%\icardagt.exe'
+  Type: 'Sideloading'
+    SHA256:
+      - 473d17e571d6947ce93103454f1e9fe27136403125152b97acb6cad5cc2a9ac7
+    ExpectedVersionInformation:
+      - CompanyName: 'Microsoft Corporation'
+        FileDescription: 'Windows CardSpace User Interface Agent'
+        FileVersion: '3.0.4506.4926 (NetFXw7.030729-4900)'
+        InternalName: 'icardagt.exe'
+        LegalCopyright: '© Microsoft Corporation.  All rights reserved.'
+        OriginalFilename: 'icardagt.exe'
+        ProductName: 'Microsoft® .NET Framework'
+        ProductVersion: '3.0.4506.4926'
+    ExpectedSignatureInformation:
+      - Type: Authenticode
+        Subject: CN=Microsoft Windows,O=Microsoft Corporation,L=Redmond,ST=Washington,C=US
+        Issuer: CN=Microsoft Windows Production PCA 2011,O=Microsoft Corporation,L=Redmond,ST=Washington,C=US
 Resources:
 - https://securityintelligence.com/posts/windows-features-dll-sideloading/
 - https://github.com/xforcered/WFH


### PR DESCRIPTION
Added VulnerableExecutable:
Path: '%SYSTEM32%\icardagt.exe'
  Type: 'Sideloading'

Background context:

The operators behind the Bumblebee malware registered the domains zenmap[.]pro and software-server[.]online, employing black hat SEO tactics or malicious advertising to manipulate DuckDuckGo search rankings. When users searched for Zenmap, DuckDuckGo linked them to software-server[.]online, which then redirected to zenmap[.]pro. There, trojanized MSI installers for Zenmap and Nmap were distributed, utilizing a DLL side-loading technique to deploy the Bumblebee malware via "version.dll" and "icardagt.exe."

-   zenmap-7.97.msi (https://www.virustotal.com/gui/file/0591fe474dd8e3e9309359ebe28ff71f07a6c9bf623674643496a618d70c4a92)
-   version.dll (https://www.virustotal.com/gui/file/96480ef5ccfa8fcb0646538c440103d97ab741ed83f4c2bcb7b4717569f88770)
-   Joe Sandbox Report Page (https://www.joesandbox.com/analysis/1694316/0/html)
-   Elastic YARA Detection Signature (https://raw.githubusercontent.com/elastic/protections-artifacts/refs/heads/main/yara/rules/Windows_Trojan_Bumblebee.yar)

